### PR TITLE
feat: implement dark mode and improve UI

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,2 @@
 # .husky/pre-commit
-npm run format:fix  $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
-git update-index --again
-
-npm run lint  $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+npx lint-staged

--- a/TODO.md
+++ b/TODO.md
@@ -6,11 +6,8 @@
 - [x] Deploy to gmozer.ca
 - [x] Format files
 - [x] Fix linting
-
-
-
-- [ ] Add pre push hook with lint and format fix
-- [ ] Deploy
+- [x] Add pre push hook with lint and format fix
+- [x] Deploy
 - [ ] Add more projects and check
 - [ ] Add Theme switch
 - [ ] Add custom logo fonts for headers

--- a/TODO.md
+++ b/TODO.md
@@ -8,11 +8,11 @@
 - [x] Fix linting
 - [x] Add pre push hook with lint and format fix
 - [x] Deploy
+- [x] Add Theme switch
+- [x] Deploy to prod
 - [ ] Add more projects and check
-- [ ] Add Theme switch
 - [ ] Add custom logo fonts for headers
 - [ ] Add better email template
-- [ ] Deploy to prod
 - [ ] Improve each detailed service page
 - [ ] Add Page transitions
 - [ ] Add more unit tests

--- a/app/(footer)/contact/page.tsx
+++ b/app/(footer)/contact/page.tsx
@@ -11,8 +11,8 @@ export const metadata = constructMetadata({
 export default function ContactPage() {
 	return (
 		<article className="container flex flex-grow">
-			<div className="w-full rounded-lg shadow-xl bg-border">
-				<div className="grid gap-8 grid-cols-1 md:grid-cols-2 px-16 py-16 mx-auto text-gray-900">
+			<div className="w-full">
+				<div className="grid gap-8 grid-cols-1 md:grid-cols-2 sm:px-16 py-16 mx-auto text-foreground">
 					<section
 						className="flex flex-col h-full"
 						aria-labelledby="contact-heading"
@@ -20,25 +20,25 @@ export default function ContactPage() {
 						<div>
 							<h1
 								id="contact-heading"
-								className="w-full mb-4 2xl:mb-6 font-logo text-4xl md:text-5xl font-bold leading-relaxed text-foreground"
+								className="w-full mb-4 2xl:mb-6 font-logo text-4xl md:text-5xl font-bold leading-relaxed"
 							>
 								Lets <span className="text-primary">chat</span> about
 								everything!
 							</h1>
-							<p className="text-gray-700 mt-8">
+							<p className="text-muted-foreground mt-8">
 								Hate forms? Send me an email instead{" "}
 								<a href="mailto:propbono@gmail.com" className="underline">
 									propbono@gmail.com
 								</a>
 							</p>
 						</div>
-						<figure className="relative w-full flex-grow max-h-[400px] mt-4">
+						<figure className="relative w-full flex-grow max-h-[400px] mt-4 rounded-ss-2xl">
 							<Image
 								src="/images/The-whole-world.png"
 								alt="World illustration"
 								fill
 								sizes="(max-width: 768px) 100vw, 50vw"
-								className="object-cover object-bottom"
+								className="object-cover object-bottom rounded-ss-2xl"
 								priority
 							/>
 						</figure>

--- a/app/(footer)/resume/layout.tsx
+++ b/app/(footer)/resume/layout.tsx
@@ -16,9 +16,9 @@ export default function ResumeLayout({
 	return (
 		<article className="min-h-[80vh] flex">
 			<div className="container">
-				<div className="flex flex-col md:flex-row flex-wrap justify-center gap-16">
+				<div className="flex flex-col sm:flex-row justify-center gap-16">
 					<nav
-						className="flex flex-col w-full max-w-96 mx-auto md:mx-0 gap-6 h-auto rounded-md p-1 text-foreground"
+						className="flex flex-col flex-grow-0 flex-1 min-w-56 w-full mx-auto md:mx-0 gap-6 h-auto rounded-md p-1 text-foreground"
 						aria-label="Resume sections"
 					>
 						{TABS.map((tab) => {
@@ -29,9 +29,9 @@ export default function ResumeLayout({
 									href={tab.url}
 									aria-current={isActive ? "page" : undefined}
 									className={cn(
-										"inline-flex items-center w-full bg-white justify-center whitespace-nowrap text-foreground rounded-lg p-3 text-balance font-medium ring-offset-white transition-all",
+										"inline-flex items-center w-full bg-white dark:bg-foreground justify-center whitespace-nowrap text-foreground dark:text-background rounded-lg p-3 text-balance font-medium ring-offset-white transition-all",
 										{
-											"text-background shadow-sm font-bold bg-primary":
+											"text-background shadow-sm font-bold bg-primary dark:bg-primary":
 												isActive,
 										},
 									)}

--- a/app/(plain)/page.tsx
+++ b/app/(plain)/page.tsx
@@ -8,7 +8,7 @@ import {
 	TECHNOLOGIES_MASTERED,
 } from "@/constants/main";
 import { SOCIALS } from "@/constants/socials";
-import { getGithubStats, MOCK_STATS } from "@/services/github";
+import { MOCK_STATS, getGithubStats } from "@/services/github";
 import type { Stat } from "@/types/stats";
 import { differenceInCalendarYears } from "date-fns";
 import Link from "next/link";
@@ -49,12 +49,12 @@ export default async function Home() {
 				className="container flex flex-col md:flex-row items-center md:justify-between gap-8"
 				aria-labelledby="hero-heading"
 			>
-				<div className="text-center md:text-left max-w-2xl order-2 md:order-none">
+				<div className="max-w-2xl order-2 md:order-none">
 					<h1 id="hero-heading" className="sr-only">
 						Greg Mozer - Senior Software Developer
 					</h1>
 					<p className="text-xl mb-2 2xl:mb-4">Senior Software Developer</p>
-					<h2 className="w-full mb-4 2xl:mb-6 font-logo text-4xl md:text-5xl font-bold leading-relaxed text-foreground">
+					<h2 className="w-full mb-4 2xl:mb-6 font-logo text-4xl md:text-5xl font-bold leading-relaxed md:leading-snug text-foreground">
 						Making the Web a{" "}
 						<span className="text-primary">More Beautiful Place</span>, One Site
 						at a Time.

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,12 +4,12 @@
 
 @layer base {
 	:root {
-		--background: #ffffff;
-		--foreground: #020817;
-		--card: #ffffff;
-		--card-foreground: #020817;
-		--popover: #ffffff;
-		--popover-foreground: #020817;
+		--background: #f5f5f5;
+		--foreground: #0e1111;
+		--card: #f8fafc;
+		--card-foreground: #0e1111;
+		--popover: #f5f5f5;
+		--popover-foreground: #0e1111;
 		--primary: #00c6bd;
 		--primary-foreground: #c1fcf6;
 		--secondary: #98005f;
@@ -34,16 +34,16 @@
 	}
 
 	.dark {
-		--background: #020817;
+		--background: #0e1111;
 		--foreground: #f8fafc;
-		--card: #020817;
-		--card-foreground: #f8fafc;
-		--popover: #020817;
-		--popover-foreground: #f8fafc;
+		--card: #f8fafc;
+		--card-foreground: #0e1111;
+		--popover: #f8fafc;
+		--popover-foreground: #0e1111;
 		--primary: #00c6bd;
 		--primary-foreground: #0f172a;
-		--secondary: #1e293b;
-		--secondary-foreground: #f8fafc;
+		--secondary: #98005f;
+		--secondary-foreground: #ffe4f9;
 		--muted: #1e293b;
 		--muted-foreground: #94a3b8;
 		--accent: #1e293b;
@@ -72,7 +72,7 @@
 	}
 
 	.text-outline {
-		-webkit-text-stroke: 1px var(--foreground);
+		-webkit-text-stroke: 1px var(--card-foreground);
 	}
 
 	.text-outline-hover {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,7 @@ import Script from "next/script";
 import type { ReactNode } from "react";
 import { siteConfig } from "./metadata";
 import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
 
 const ubuntu = Ubuntu({
 	subsets: ["latin"],
@@ -39,7 +40,7 @@ export default function RootLayout({
 	children,
 }: Readonly<{ children: ReactNode }>) {
 	return (
-		<html lang="en">
+		<html lang="en" suppressHydrationWarning>
 			<head>
 				<link
 					rel="apple-touch-icon"
@@ -61,10 +62,16 @@ export default function RootLayout({
 				<link rel="manifest" href="/site.webmanifest" />
 			</head>
 			<body
-				className={cn("flex flex-col min-h-screen min-w-72", ubuntu.variable)}
+				className={cn(
+					"flex flex-col min-h-screen min-w-72 bg-background",
+					ubuntu.variable,
+				)}
 			>
 				<PostHogProvider>
-					<TooltipProvider delayDuration={150}>{children}</TooltipProvider>
+					<ThemeProvider>
+						<TooltipProvider delayDuration={150}>{children}</TooltipProvider>
+					</ThemeProvider>
+
 					<Toaster />
 					<Script type="application/ld+json">{JSON.stringify(jsonLd)}</Script>
 				</PostHogProvider>

--- a/components/header/index.tsx
+++ b/components/header/index.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { DesktopNav } from "../desktop-nav";
 import { MobileNav } from "../mobile-nav";
+import { ThemeSwitch } from "../theme-switch";
 
 export const Header = () => {
 	const pathname = usePathname();
@@ -50,7 +51,10 @@ export const Header = () => {
 						<span className="text-primary group-hover:text-foreground">.</span>
 					</span>
 				</Link>
-				{isMediumBreakpoint ? memoizedDesktopNav : memoizedMobileNav}
+				<div className="flex flex-row-reverse sm:flex-row items-center gap-4">
+					{isMediumBreakpoint ? memoizedDesktopNav : memoizedMobileNav}
+					<ThemeSwitch />
+				</div>
 			</div>
 		</header>
 	);

--- a/components/hero-photo/index.tsx
+++ b/components/hero-photo/index.tsx
@@ -17,7 +17,7 @@ export const HeroPhoto = () => {
 						opacity: 1,
 						transition: { delay: 0.5, duration: 0.4, ease: "easeInOut" },
 					}}
-					className="absolute w-[298px] h-[298px] md:w-[398px] md:h-[398px] 2xl:w-[498px] 2xl:h-[498px] mix-blend-darken"
+					className="absolute w-[298px] h-[298px] md:w-[398px] md:h-[398px] 2xl:w-[498px] 2xl:h-[498px]"
 				>
 					<Image
 						priority

--- a/components/project-showcase.tsx
+++ b/components/project-showcase.tsx
@@ -100,7 +100,7 @@ export function ProjectShowcase() {
 							</span>
 							<h1
 								id="project-title"
-								className="leading-tight font-bold text-4xl sm:text-5xl text-foreground group-hover:text-primary transition-all duration-500 capitalize mb-6 line-clamp-2"
+								className="leading-tight font-bold text-4xl sm:text-5xl text-card-foreground group-hover:text-primary transition-all duration-500 capitalize mb-6 line-clamp-2"
 							>
 								{currentProject.title}
 							</h1>
@@ -133,8 +133,8 @@ export function ProjectShowcase() {
 									{!!currentProject.liveLink && (
 										<Link href={currentProject.liveLink}>
 											<Tooltip>
-												<TooltipTrigger className="size-16 rounded-full border border-foreground flex justify-center items-center group hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100">
-													<RiArrowRightDownLine className="text-3xl text-foreground group-hover:text-primary group-hover:-rotate-45 transition-all duration-500" />
+												<TooltipTrigger className="size-16 rounded-full border border-card-foreground flex justify-center items-center group hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100">
+													<RiArrowRightDownLine className="text-3xl text-card-foreground group-hover:text-primary group-hover:-rotate-45 transition-all duration-500" />
 													<span className="sr-only">
 														{currentProject.title} - Live Project
 													</span>
@@ -146,8 +146,8 @@ export function ProjectShowcase() {
 									{!!currentProject.githubLink && (
 										<Link href={currentProject.githubLink}>
 											<Tooltip>
-												<TooltipTrigger className="size-16 rounded-full border border-foreground flex justify-center items-center group hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100">
-													<RiGithubLine className="text-3xl text-foreground group-hover:text-primary transition-all duration-500" />
+												<TooltipTrigger className="size-16 rounded-full border border-card-foreground flex justify-center items-center group hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100">
+													<RiGithubLine className="text-3xl text-card-foreground group-hover:text-primary transition-all duration-500" />
 													<span className="sr-only">
 														{currentProject.title} - Github Repository
 													</span>
@@ -164,9 +164,9 @@ export function ProjectShowcase() {
 												onClick={handlePrevious}
 												disabled={!api?.canScrollPrev()}
 												variant="ghost"
-												className="size-16 rounded-full border border-foreground flex justify-center items-center group hover:bg-white hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100"
+												className="size-16 rounded-full border border-card-foreground flex justify-center items-center group hover:bg-white hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100"
 											>
-												<RiArrowLeftSLine className="text-3xl text-foreground group-hover:text-primary transition-all duration-500" />
+												<RiArrowLeftSLine className="text-3xl text-card-foreground group-hover:text-primary transition-all duration-500" />
 												<span className="sr-only">Previous Project</span>
 											</Button>
 										</TooltipTrigger>
@@ -178,9 +178,9 @@ export function ProjectShowcase() {
 												onClick={handleNext}
 												disabled={!api?.canScrollNext()}
 												variant="ghost"
-												className="size-16 rounded-full border border-foreground flex justify-center items-center group hover:bg-white hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100"
+												className="size-16 rounded-full border border-card-foreground flex justify-center items-center group hover:bg-white hover:border-primary hover:border-2 hover:border-dashed hover:transition-all hover:duration-100"
 											>
-												<RiArrowRightSLine className="text-3xl text-foreground group-hover:text-primary transition-all duration-500" />
+												<RiArrowRightSLine className="text-3xl text-card-foreground group-hover:text-primary transition-all duration-500" />
 												<span className="sr-only">Next Project</span>
 											</Button>
 										</TooltipTrigger>

--- a/components/stats/index.tsx
+++ b/components/stats/index.tsx
@@ -4,11 +4,11 @@ import type { Stat } from "@/types/stats";
 import CountUp from "react-countup";
 export const Stats = ({ stats }: { stats: Stat[] }) => {
 	return (
-		<div className="grid grid-cols-2 md:flex md:flex-row md:flex-wrap w-full gap-4 justify-between">
+		<div className="flex flex-col md:flex-row md:flex-wrap w-full gap-4 justify-between">
 			{stats.map((stat) => (
 				<div
 					key={stat.title}
-					className="flex flex-row gap-4 items-center justify-start md:justify-end"
+					className="grid grid-cols-2 md:flex md:flex-row gap-9 md:gap-4 items-center md:justify-end"
 				>
 					<div className="min-w-[4ch] font-mono text-right">
 						<CountUp

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+import { ThemeProvider as NextThemeProvider } from "next-themes";
+import type { ReactNode } from "react";
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+	return (
+		<NextThemeProvider attribute="class" defaultTheme="system" enableSystem>
+			{children}
+		</NextThemeProvider>
+	);
+};

--- a/components/theme-switch.tsx
+++ b/components/theme-switch.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { LuMoon, LuSun } from "react-icons/lu";
+import { Button } from "./ui/button";
+
+export const ThemeSwitch = () => {
+	const { theme, setTheme } = useTheme();
+
+	return (
+		<Button
+			variant="ghost"
+			size="icon"
+			onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+		>
+			<LuSun className="size-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+			<LuMoon className="absolute size-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+			<span className="sr-only">Toggle theme</span>
+		</Button>
+	);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
 				"@vitest/coverage-v8": "^3.1.1",
 				"husky": "^9.1.7",
 				"jsdom": "^25.0.1",
+				"lint-staged": "^15.5.1",
 				"postcss": "^8",
 				"tailwindcss": "^3.4.1",
 				"typescript": "^5",
@@ -3150,6 +3151,22 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/ansi-escapes": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
+			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"environment": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -3488,6 +3505,64 @@
 				"url": "https://polar.sh/cva"
 			}
 		},
+		"node_modules/cli-cursor": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"restore-cursor": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"slice-ansi": "^5.0.0",
+				"string-width": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/cli-truncate/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cli-truncate/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/client-only": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3519,6 +3594,13 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/colorette": {
+			"version": "2.0.20",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/combined-stream": {
@@ -3868,6 +3950,19 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/environment": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -3979,6 +4074,37 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
 		"node_modules/expect-type": {
@@ -4179,6 +4305,19 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
+			"integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/get-intrinsic": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4223,6 +4362,19 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/glob": {
@@ -4417,6 +4569,16 @@
 				"node": ">= 14"
 			}
 		},
+		"node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
 		"node_modules/husky": {
 			"version": "9.1.7",
 			"resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -4528,6 +4690,19 @@
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -4713,12 +4888,246 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"license": "MIT"
 		},
+		"node_modules/lint-staged": {
+			"version": "15.5.1",
+			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.1.tgz",
+			"integrity": "sha512-6m7u8mue4Xn6wK6gZvSCQwBvMBR36xfY24nF5bMTf2MHDYG6S3yhJuOgdYVw99hsjyDt2d4z168b3naI8+NWtQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chalk": "^5.4.1",
+				"commander": "^13.1.0",
+				"debug": "^4.4.0",
+				"execa": "^8.0.1",
+				"lilconfig": "^3.1.3",
+				"listr2": "^8.2.5",
+				"micromatch": "^4.0.8",
+				"pidtree": "^0.6.0",
+				"string-argv": "^0.3.2",
+				"yaml": "^2.7.0"
+			},
+			"bin": {
+				"lint-staged": "bin/lint-staged.js"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/lint-staged"
+			}
+		},
+		"node_modules/lint-staged/node_modules/chalk": {
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
+			"integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/lint-staged/node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/listr2": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.2.tgz",
+			"integrity": "sha512-vsBzcU4oE+v0lj4FhVLzr9dBTv4/fHIa57l+GCwovP8MoFNZJTOhGU8PXd4v2VJCbECAaijBiHntiekFMLvo0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cli-truncate": "^4.0.0",
+				"colorette": "^2.0.20",
+				"eventemitter3": "^5.0.1",
+				"log-update": "^6.1.0",
+				"rfdc": "^1.4.1",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/listr2/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/listr2/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/listr2/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/listr2/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/log-update": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+			"integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-escapes": "^7.0.0",
+				"cli-cursor": "^5.0.0",
+				"slice-ansi": "^7.1.0",
+				"strip-ansi": "^7.1.0",
+				"wrap-ansi": "^9.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/log-update/node_modules/emoji-regex": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/log-update/node_modules/is-fullwidth-code-point": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
+			"integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/slice-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
+			"integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"is-fullwidth-code-point": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/log-update/node_modules/string-width": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^10.3.0",
+				"get-east-asian-width": "^1.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/log-update/node_modules/wrap-ansi": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
+			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.2.1",
+				"string-width": "^7.0.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
@@ -4829,6 +5238,13 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/merge-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4870,6 +5286,32 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/min-indent": {
@@ -5061,6 +5503,35 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm-run-path/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/nwsapi": {
 			"version": "2.2.20",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -5105,6 +5576,22 @@
 			},
 			"engines": {
 				"node": ">= 18"
+			}
+		},
+		"node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/package-json-from-dist": {
@@ -5218,6 +5705,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pidtree": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"pidtree": "bin/pidtree.js"
+			},
+			"engines": {
+				"node": ">=0.10"
 			}
 		},
 		"node_modules/pify": {
@@ -5740,6 +6240,39 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/restore-cursor": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"onetime": "^7.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/restore-cursor/node_modules/onetime": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/reusify": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5749,6 +6282,13 @@
 				"iojs": ">=1.0.0",
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/rfdc": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/rollup": {
 			"version": "4.39.0",
@@ -5911,6 +6451,49 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/slice-ansi": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.0.0",
+				"is-fullwidth-code-point": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -5940,6 +6523,16 @@
 			"integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
 			"engines": {
 				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/string-argv": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6.19"
 			}
 		},
 		"node_modules/string-width": {
@@ -6030,6 +6623,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/strip-indent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"framer-motion": "^11.3.21",
 				"lucide-react": "^0.424.0",
 				"next": "^14.2.26",
+				"next-themes": "^0.4.6",
 				"octokit": "^4.0.2",
 				"posthog-js": "^1.234.9",
 				"posthog-node": "^4.11.1",
@@ -5004,6 +5005,16 @@
 				"sass": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/next-themes": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+			"integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+				"react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
 			}
 		},
 		"node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"framer-motion": "^11.3.21",
 		"lucide-react": "^0.424.0",
 		"next": "^14.2.26",
+		"next-themes": "^0.4.6",
 		"octokit": "^4.0.2",
 		"posthog-js": "^1.234.9",
 		"posthog-node": "^4.11.1",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,14 @@
 		"@vitest/coverage-v8": "^3.1.1",
 		"husky": "^9.1.7",
 		"jsdom": "^25.0.1",
+		"lint-staged": "^15.5.1",
 		"postcss": "^8",
 		"tailwindcss": "^3.4.1",
 		"typescript": "^5",
 		"vitest": "^3.1.1"
+	},
+	"lint-staged": {
+		"*.{js, jsx,ts,tsx}": ["npm run lint"],
+		"*.{json,js,ts,jsx,tsx,html}": ["npm run format:fix"]
 	}
 }


### PR DESCRIPTION
This commit introduces dark mode functionality using `next-themes`. It also includes several UI improvements:

-   **Dark Mode:** Implemented dark mode using `next-themes` and updated CSS variables to support both light and dark themes. A theme switch component was added to the header.
-   **Color Palette:** Updated the color palette in `globals.css` to provide better contrast and aesthetics for both light and dark modes.
-   **Project Showcase:** Adjusted the `ProjectShowcase` component to use the new color variables for improved visual consistency.
-   **Contact Page:** Updated the contact page to use the new color variables and adjusted the layout for better responsiveness.
-   **Resume Layout:** Modified the resume layout to improve the appearance of the navigation tabs in both light and dark modes.
-   **Homepage:** Refactored the homepage to use the new color variables and adjusted the layout of the stats section.
-   **Hero Photo:** Removed `mix-blend-darken` from the hero photo to ensure it displays correctly in both light and dark modes.